### PR TITLE
Delete .flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 80
-max-complexity = 10
-extend-ignore = E203
-per-file-ignores = __init__.py:F401


### PR DESCRIPTION
Удалён конфиг для flake8, так как flake8 больше не используется. Вместо него используется Ruff